### PR TITLE
Add basic Go serial support

### DIFF
--- a/cmd/rdsd/main.go
+++ b/cmd/rdsd/main.go
@@ -1,0 +1,22 @@
+package main
+
+import (
+	"log"
+	"time"
+
+	"uecprds/pkg/uecprds"
+)
+
+func main() {
+	rds := uecprds.New("/dev/ttyUSB0", 9600, time.Second)
+	if err := rds.Open(); err != nil {
+		log.Fatalf("open serial: %v", err)
+	}
+	defer rds.Close()
+
+	// Example frame - in a real application build a proper UECP frame.
+	frame := []byte{0x00, 0x00}
+	if err := rds.Send(frame); err != nil {
+		log.Fatalf("send: %v", err)
+	}
+}

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,5 @@
+module uecprds
+
+go 1.21
+
+require go.bug.st/serial v1.5.0

--- a/pkg/uecprds/uecprds.go
+++ b/pkg/uecprds/uecprds.go
@@ -1,0 +1,64 @@
+package uecprds
+
+import (
+	"time"
+
+	"go.bug.st/serial"
+)
+
+// UECPRDS provides minimal UECP RDS encoder implementation.
+type UECPRDS struct {
+	device string
+	baud   int
+	delay  time.Duration
+	port   serial.Port
+}
+
+// New returns a new UECPRDS instance configured for the given serial settings.
+func New(device string, baud int, delay time.Duration) *UECPRDS {
+	return &UECPRDS{device: device, baud: baud, delay: delay}
+}
+
+// Open opens the configured serial port.
+func (u *UECPRDS) Open() error {
+	if u.port != nil {
+		return nil
+	}
+	mode := &serial.Mode{BaudRate: u.baud}
+	p, err := serial.Open(u.device, mode)
+	if err != nil {
+		return err
+	}
+	u.port = p
+	return nil
+}
+
+// Close closes the serial port if it is open.
+func (u *UECPRDS) Close() error {
+	if u.port != nil {
+		err := u.port.Close()
+		u.port = nil
+		return err
+	}
+	return nil
+}
+
+// sendGroup writes the provided frame to the serial port.
+func (u *UECPRDS) sendGroup(frame []byte) error {
+	if err := u.Open(); err != nil {
+		return err
+	}
+	if _, err := u.port.Write(frame); err != nil {
+		return err
+	}
+	if err := u.port.Flush(); err != nil {
+		return err
+	}
+	time.Sleep(u.delay)
+	return nil
+}
+
+// Send exposes sendGroup for external callers.
+func (u *UECPRDS) Send(frame []byte) error {
+	return u.sendGroup(frame)
+}


### PR DESCRIPTION
## Summary
- add go.bug.st/serial dependency
- implement a minimal `UECPRDS` Go package with serial port management
- create a sample `cmd/rdsd` program using the new package

## Testing
- `go mod tidy` *(fails: Get "https://proxy.golang.org/go.bug.st/serial/@v/v1.5.0.zip": Forbidden)*
- `go build ./cmd/rdsd` *(fails: missing go.sum entry for go.bug.st/serial)*

------
https://chatgpt.com/codex/tasks/task_e_684b40729bf0832f823f1e16b696382b